### PR TITLE
Fix running on Windows, minor typos, unused imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Download breached password list from magnet located here:
 magnet:?xt=urn:btih:7ffbcd8cee06aba2ce6561688cf68ce2addca0a3&dn=BreachCompilation&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fglotorrents.pw%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337
 ```
 
-I reccomend editing line 24 and adding your `BreachCompilation/data` directory as the default `datafile` value or you will need to use the `datafile` parameter:
+I recommend editing line 24 and adding your `BreachCompilation/data` directory as the default `datafile` value or you will need to use the `datafile` parameter:
 
 `py breach-parse.py @yahoo.com yahoo --datafile "/media/adam/BreachCompilation/data"`
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # breach-parse.py
 
 ## Synposis
-The same [breach-parse](https://github.com/hmaverickadams/breach-parse) tool from [hmaverickadams](https://github.com/hmaverickadams) but written in python3. Only works on Linux.. sorry Windows users. 
+The same [breach-parse](https://github.com/hmaverickadams/breach-parse) tool from [hmaverickadams](https://github.com/hmaverickadams) but written in python3.
 
 ## Description
 This tool runs about a minute faster than it's bash counterpart and is more accurate when searching. 

--- a/breach-parse.py
+++ b/breach-parse.py
@@ -1,9 +1,7 @@
 import argparse
 import textwrap
-import time
 from timeit import default_timer as timer
 from multiprocessing import Pool, cpu_count
-import glob
 import os.path
 from contextlib import ExitStack
 

--- a/breach-parse.py
+++ b/breach-parse.py
@@ -100,7 +100,7 @@ def search_file(files, search_term):
     results = []
     
     with ExitStack() as stack:
-        working_files = [stack.enter_context(open(x, "rb")) for x in files]
+        working_files = [stack.enter_context(open(x, "r", encoding="latin-1")) for x in files]
         for lines in working_files:
             for line in lines:
                 #if insensitive:
@@ -123,11 +123,10 @@ def out_file(results, out_filename):
         file name
     """
     
-    with open(out_filename, 'w') as f:
+    with open(out_filename, 'w', encoding="utf-8") as f:
         for row in results:
             for item in row:
-                data = item.decode('utf-8')
-                f.writelines(data)
+                f.writelines(item)
     
     print(f"file saved: {out_filename}")
 
@@ -142,16 +141,15 @@ def out_user_file(results, out_filename):
         file name
     """
 
-    with open(out_filename, 'w') as f:
+    with open(out_filename, 'w', encoding="utf-8") as f:
         for row in results:
             for item in row:
                 try:
-                    data = item.decode('utf-8')
-                    x = data.split(':', 1)
+                    x = item.split(':', 1)
                     
                     # some entries use ';' as a delimiter
                     if len(x) < 2:
-                        x = data.split(';', 1)
+                        x = item.split(';', 1)
 
                     f.writelines(f"{x[0]}\n")
                     
@@ -171,16 +169,14 @@ def out_password_file(results, out_filename):
         file name
     """
 
-    with open(out_filename, 'w') as f:
+    with open(out_filename, 'w', encoding="utf-8") as f:
         for row in results:
             for item in row:
                 try:
-                    data = item.decode('utf-8')
-                    
-                    x = data.split(':', 1)
+                    x = item.split(':', 1)
                     # some entries use ';' as a delimiter
                     if len(x) < 2:
-                        x = data.split(';', 1) 
+                        x = item.split(';', 1) 
                     
                     f.writelines(x[1])
                 
@@ -196,7 +192,6 @@ def main():
     args = get_args()
     out_filename = args['output']
     term = args['term']
-    b_term = str.encode(term)
     userfile = args['userfile']
     passwordfile = args['passwordfile']
 
@@ -205,7 +200,7 @@ def main():
     # prep search
     breach_fpath = args['datafile']
     breach_data_files = get_breach_files(breach_fpath) # get all txt breach files
-    queue = format_data(breach_data_files, b_term) # prep data for the pool
+    queue = format_data(breach_data_files, term) # prep data for the pool
     
     # start multi threaded search
     with Pool() as pool:

--- a/breach-parse.py
+++ b/breach-parse.py
@@ -218,7 +218,7 @@ def main():
         out_password_file(res, f"{out_filename}_passwords.txt")
     
     end = timer()
-    print(f"elpased time: {end - start}")
+    print(f"elapsed time: {end - start}")
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
If proper character encodings are given to `open`, code runs successfully on Windows as well.

```
PS C:\Users\Tesch\Desktop\breach-parse> python .\breach-parse.py password out          
starting search on 20 cores
search complete!
saving results
file saved: out.txt
elapsed time: 24.03903949999949
```

* Verified it still runs on Linux successfully
* Verified Linux/Windows output is the same
