### PR TITLE
Fix format_data

### DIFF
--- a/breach-parse.py
+++ b/breach-parse.py
@@ -65,17 +65,9 @@ def format_data(files, term):
     """
 
     data = []
-    five_files = []
-    count = 0
-    for file in files:
-        if count == 5:
-            data.append([five_files, term])
-            five_files = []
-            count = 0
-        else:
-            five_files.append(file)
-            count += 1
-
+    for i in range(0, len(files), 5):
+        data.append([files[i:i+5], term])
+    
     return data
 
 def search_file(files, search_term):


### PR DESCRIPTION
`format_data` currently skips every 6th file, and can skip up to the last 4 files.

Based on testing with numerical data, the current `format_data` function returns this for `range(25)` (skipping 5, 11, 17, 23, 24):

```py
[[[0, 1, 2, 3, 4], 'term'], [[6, 7, 8, 9, 10], 'term'], [[12, 13, 14, 15, 16], 'term'], [[18, 19, 20, 21, 22], 'term']]
```

This PR implements a `format_data` function that returns the following:

```py
[[[0, 1, 2, 3, 4], 'term'], [[5, 6, 7, 8, 9], 'term'], [[10, 11, 12, 13, 14], 'term'], [[15, 16, 17, 18, 19], 'term'], [[20, 21, 22, 23, 24], 'term']]
```